### PR TITLE
resolve issue #14 and prepare to be logged in sensors database

### DIFF
--- a/Go/diopsid/DiopsidConfig.json
+++ b/Go/diopsid/DiopsidConfig.json
@@ -1,9 +1,8 @@
 {
-	"log-level": "INFO",
-	"subscribe-queue": "diopsid_namchinename",
-	"alerts-queue": "disk_status.machinename",
-	"broker": "higgsino.physics.ucsb.edu",
-	"where-to-look": ["/data/hot","/data/warm"],
-	"wait-interval": "1m"
-
+    "log-level": "INFO",
+    "subscribe-queue": "diopsid_{machine}",
+    "alerts-queue-base": "sensor_value.disks_{machine}_",
+    "broker": "localhost",
+    "where-to-look": ["/data/disk1","/data/disk2"],
+    "wait-interval": "1m"
 }

--- a/Go/diopsid/DiopsidConfig.yaml
+++ b/Go/diopsid/DiopsidConfig.yaml
@@ -1,0 +1,8 @@
+subscribe-queue: diopsid_{machine}
+alerts-queue-base: sensor_value.disks_{machine}_ # trailing _ preserves alerts queue formatting
+broker: localhost
+where-to-look:
+  - /data/disk1
+  - /data/disk2
+wait-interval: 1m
+log-level: INFO


### PR DESCRIPTION
1. Change calculation of Used/Available space to match `df`.
1. Make payload fields match sensor_logger expectation for loading straight into database.

This should be accompanied by a changes:
1. In hardware/software_config/diopsid to use a sensor_value.# "alerts-queue"
1. Endpoints added to the database
1. Adopt the new sensor_monitor, or else modify disk_monitor.py to handle the changes.